### PR TITLE
[Feature/#19] : 카카오 로그인 API 연동

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -29,6 +29,8 @@ android {
         }
 
         buildConfigField("String", "PLOG_BASE_URL", properties["plog.base.url"].toString())
+        buildConfigField("String", "KAKAO_API_KEY", properties["kakao.api.key"].toString())
+        resValue("string", "KAKAO_REDIRECT_URI", properties["kakao.redirect.uri"].toString())
     }
 
     buildTypes {
@@ -41,11 +43,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
     kotlinOptions {
-        jvmTarget = "17"
+        jvmTarget = "1.8"
     }
     buildFeatures {
         compose = true
@@ -139,4 +141,8 @@ dependencies {
 
     // Accompanist System UI Controller
     implementation(libs.accompanist.systemuicontroller)
+
+    // Kakao
+    implementation(libs.kakao.all)
+    implementation(libs.kakao.user)
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,6 +18,21 @@
         android:theme="@style/Theme.Plog"
         tools:targetApi="31">
         <activity
+            android:name="com.kakao.sdk.auth.AuthCodeHandlerActivity"
+            android:exported="true"
+            android:launchMode="singleTask">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:host="oauth"
+                    android:scheme="@string/KAKAO_REDIRECT_URI" />
+            </intent-filter>
+        </activity>
+        <activity
             android:name=".presentation.main.MainActivity"
             android:exported="true"
             android:label="@string/app_name"

--- a/app/src/main/java/com/kpaas/plog/PlogApp.kt
+++ b/app/src/main/java/com/kpaas/plog/PlogApp.kt
@@ -1,6 +1,7 @@
 package com.kpaas.plog
 
 import android.app.Application
+import com.kakao.sdk.common.KakaoSdk
 import com.naver.maps.map.NaverMapSdk
 import dagger.hilt.android.HiltAndroidApp
 import timber.log.Timber
@@ -12,6 +13,7 @@ class PlogApp : Application() {
         setTimber()
         NaverMapSdk.getInstance(this).client =
             NaverMapSdk.NaverCloudPlatformClient(NAVER_MAP_CLIENT_ID)
+        KakaoSdk.init(this, BuildConfig.KAKAO_API_KEY)
     }
 
     private fun setTimber() {

--- a/app/src/main/java/com/kpaas/plog/presentation/auth/screen/LoginScreen.kt
+++ b/app/src/main/java/com/kpaas/plog/presentation/auth/screen/LoginScreen.kt
@@ -51,15 +51,10 @@ fun LoginRoute(
 
     LaunchedEffect(loginState) {
         when (loginState) {
-            is UiState.Success -> {
-                // 로그인 성공 시 처리
-                authNavigator.navigateBoarding()
-            }
-
+            is UiState.Success -> { authNavigator.navigateBoarding() }
             is UiState.Failure -> {
 
             }
-
             else -> {}
         }
     }

--- a/app/src/main/java/com/kpaas/plog/presentation/auth/screen/LoginScreen.kt
+++ b/app/src/main/java/com/kpaas/plog/presentation/auth/screen/LoginScreen.kt
@@ -16,14 +16,19 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.kpaas.plog.R
 import com.kpaas.plog.core_ui.theme.Gray350
 import com.kpaas.plog.core_ui.theme.Gray600
@@ -33,13 +38,34 @@ import com.kpaas.plog.core_ui.theme.body3Regular
 import com.kpaas.plog.core_ui.theme.title1Bold
 import com.kpaas.plog.core_ui.theme.title2Semi
 import com.kpaas.plog.presentation.auth.navigation.AuthNavigator
+import com.kpaas.plog.presentation.auth.viewmodel.LoginViewModel
+import com.kpaas.plog.util.UiState
 
 @Composable
 fun LoginRoute(
     authNavigator: AuthNavigator
 ) {
+    val context = LocalContext.current
+    val viewModel: LoginViewModel = hiltViewModel()
+    val loginState by viewModel.loginState.collectAsState()
+
+    LaunchedEffect(loginState) {
+        when (loginState) {
+            is UiState.Success -> {
+                // 로그인 성공 시 처리
+                authNavigator.navigateBoarding()
+            }
+
+            is UiState.Failure -> {
+
+            }
+
+            else -> {}
+        }
+    }
+
     LoginScreen(
-        onKakaoButtonClick = { authNavigator.navigateSignup() },
+        onKakaoButtonClick = { viewModel.loginWithKakao() },
         onNaverButtonClick = {},
     )
 }

--- a/app/src/main/java/com/kpaas/plog/presentation/auth/screen/LoginScreen.kt
+++ b/app/src/main/java/com/kpaas/plog/presentation/auth/screen/LoginScreen.kt
@@ -40,6 +40,7 @@ import com.kpaas.plog.core_ui.theme.title2Semi
 import com.kpaas.plog.presentation.auth.navigation.AuthNavigator
 import com.kpaas.plog.presentation.auth.viewmodel.LoginViewModel
 import com.kpaas.plog.util.UiState
+import timber.log.Timber
 
 @Composable
 fun LoginRoute(
@@ -51,16 +52,20 @@ fun LoginRoute(
 
     LaunchedEffect(loginState) {
         when (loginState) {
-            is UiState.Success -> { authNavigator.navigateBoarding() }
-            is UiState.Failure -> {
-
+            is UiState.Success -> {
+                authNavigator.navigateBoarding()
             }
+
+            is UiState.Failure -> {
+                Timber.e("Login failed: $loginState")
+            }
+
             else -> {}
         }
     }
 
     LoginScreen(
-        onKakaoButtonClick = { viewModel.loginWithKakao() },
+        onKakaoButtonClick = { viewModel.signInWithKakao(context) },
         onNaverButtonClick = {},
     )
 }

--- a/app/src/main/java/com/kpaas/plog/presentation/auth/screen/LoginViewModel.kt
+++ b/app/src/main/java/com/kpaas/plog/presentation/auth/screen/LoginViewModel.kt
@@ -7,6 +7,7 @@ import com.kakao.sdk.auth.Constants.UNKNOWN_ERROR
 import com.kakao.sdk.auth.model.OAuthToken
 import com.kakao.sdk.user.UserApiClient
 import com.kpaas.plog.util.UiState
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -15,6 +16,7 @@ import javax.inject.Inject
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 
+@HiltViewModel
 class LoginViewModel @Inject constructor() : ViewModel() {
 
     private val _loginState = MutableStateFlow<UiState<String>>(UiState.Empty)

--- a/app/src/main/java/com/kpaas/plog/presentation/auth/screen/LoginViewModel.kt
+++ b/app/src/main/java/com/kpaas/plog/presentation/auth/screen/LoginViewModel.kt
@@ -1,0 +1,65 @@
+package com.kpaas.plog.presentation.auth.viewmodel
+
+import android.app.Application
+import android.content.Context
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import com.kakao.sdk.common.model.ClientError
+import com.kakao.sdk.common.model.ClientErrorCause
+import com.kakao.sdk.user.UserApiClient
+import com.kpaas.plog.util.UiState
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import timber.log.Timber
+
+class LoginViewModel(application: Application) : AndroidViewModel(application) {
+
+    private val _loginState = MutableStateFlow<UiState<String>>(UiState.Empty)
+    val loginState: StateFlow<UiState<String>> = _loginState
+
+    fun loginWithKakao() {
+        viewModelScope.launch {
+            _loginState.value = UiState.Loading
+
+            val context = getApplication<Application>().applicationContext
+
+            // 카카오톡이 설치되어 있으면 카카오톡으로 로그인, 아니면 카카오계정으로 로그인
+            if (UserApiClient.instance.isKakaoTalkLoginAvailable(context)) {
+                UserApiClient.instance.loginWithKakaoTalk(context) { token, error ->
+                    if (error != null) {
+                        // 카카오톡으로 로그인 실패 시 처리
+                        if (error is ClientError && error.reason == ClientErrorCause.Cancelled) {
+                            _loginState.value = UiState.Failure("카카오톡 로그인 취소")
+                            return@loginWithKakaoTalk
+                        } else {
+                            _loginState.value = UiState.Failure("카카오톡 로그인 실패: ${error.message}")
+                            // 카카오톡에 연결된 카카오계정이 없는 경우, 카카오계정으로 로그인 시도
+                            loginWithKakaoAccount(context)
+                        }
+                    } else if (token != null) {
+                        // 카카오톡으로 로그인 성공 시 처리
+                        _loginState.value = UiState.Success("카카오톡 로그인 성공: ${token.accessToken}")
+                        Timber.d("카카오톡 로그인 성공: ${token.accessToken}")
+                    }
+                }
+            } else {
+                // 카카오톡이 설치되지 않은 경우, 카카오계정으로 로그인
+                loginWithKakaoAccount(context)
+            }
+        }
+    }
+
+    private fun loginWithKakaoAccount(context: Context) {
+        UserApiClient.instance.loginWithKakaoAccount(context) { token, error ->
+            if (error != null) {
+                // 카카오계정으로 로그인 실패 시 처리
+                _loginState.value = UiState.Failure("카카오계정 로그인 실패: ${error.message}")
+            } else if (token != null) {
+                // 카카오계정으로 로그인 성공 시 처리
+                _loginState.value = UiState.Success("카카오계정 로그인 성공: ${token.accessToken}")
+                Timber.d("카카오계정 로그인 성공: ${token.accessToken}")
+            }
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -49,6 +49,9 @@ naver-map-compose = "1.7.2"
 naver-map-location = "21.0.2"
 play-services-location = "21.0.1"
 
+# Kakao
+kakao = "2.20.1"
+
 viewpager-indicator = "5.0"
 
 # Hilt
@@ -140,6 +143,9 @@ naver-map-compose = { group = "io.github.fornewid", name = "naver-map-compose", 
 naver-map-location = { group = "io.github.fornewid", name = "naver-map-location", version.ref = "naver-map-location" } # 네이버 지도 위치 라이브러리
 play-services-location = { group = "com.google.android.gms", name = "play-services-location", version.ref = "play-services-location" } # Play Services Location 라이브러리
 
+# Kakao
+kakao-all = { group = "com.kakao.sdk", name = "v2-all", version.ref = "kakao" } # Kakao SDK 라이브러리
+kakao-user = { group = "com.kakao.sdk", name = "v2-user", version.ref = "kakao" } # Kakao 로그인 라이브러리
 
 # Hilt
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" } # Hilt Android 라이브러리

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,6 +17,7 @@ dependencyResolutionManagement {
         google()
         mavenCentral()
         maven("https://repository.map.naver.com/archive/maven")
+        maven ("https://devrepo.kakao.com/nexus/content/groups/public/")
     }
 }
 


### PR DESCRIPTION
## ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- merge할 브랜치의 위치를 확인해 주세요.(main❌/develop⭕)
- 리뷰가 필요한 경우 리뷰어를 지정해 주세요.
- 리뷰는 PR이 올라오면 최대한 빠르게 진행합니다.
- P1 단계의 리뷰는 빠르게 확인 후 반영합니다.
- Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.

## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #19 

## 📎 𝗪𝗼𝗿𝗸 𝗗𝗲𝘀𝗰𝗿𝗶𝗽𝘁𝗶𝗼𝗻
- 카카오 로그인 API 연동

## 📷 𝗦𝗰𝗿𝗲𝗲𝗻𝘀𝗵𝗼𝘁
https://github.com/user-attachments/assets/d3636877-eda3-42d2-a563-0a6c14b64014

## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀
네이버 로그인까지 구현한 다음에 토큰 저장 로직 추가하겠습니다.