### PR TITLE
[Feature/#49] : 플로깅 정보 datastore로 마이그레이션

### DIFF
--- a/app/src/main/java/com/kpaas/plog/app/di/PloggingPreferencesModule.kt
+++ b/app/src/main/java/com/kpaas/plog/app/di/PloggingPreferencesModule.kt
@@ -4,10 +4,10 @@ import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.preferencesDataStore
-import com.kpaas.plog.data.datasource.UserPreferencesDataSource
-import com.kpaas.plog.data.datasourceimpl.UserPreferencesDataSourceImpl
-import com.kpaas.plog.data.repositoryimpl.UserPreferencesRepositoryImpl
-import com.kpaas.plog.domain.repository.UserPreferencesRepository
+import com.kpaas.plog.data.datasource.PloggingPreferencesDataSource
+import com.kpaas.plog.data.datasourceimpl.PloggingPreferencesDataSourceImpl
+import com.kpaas.plog.data.repositoryimpl.PloggingPreferencesRepositoryImpl
+import com.kpaas.plog.domain.repository.PloggingPreferencesRepository
 import dagger.Binds
 import dagger.Module
 import dagger.Provides
@@ -18,23 +18,23 @@ import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
-object UserPreferencesModule {
-    private const val USER_PREFERENCES = "user_preferences"
-    private val Context.userDataStore by preferencesDataStore(name = USER_PREFERENCES)
+object PloggingPreferencesModule {
+    private const val PLOGGING_PREFERENCES = "plogging_preferences"
+    private val Context.ploggingDataStore by preferencesDataStore(name = PLOGGING_PREFERENCES)
 
     @Provides
     @Singleton
-    @UserPreferences
+    @PloggingPreferences
     fun provideDataStore(
         @ApplicationContext context: Context
-    ): DataStore<Preferences> = context.userDataStore
+    ): DataStore<Preferences> = context.ploggingDataStore
 
     @Module
     @InstallIn(SingletonComponent::class)
     interface DataSourceModule {
         @Singleton
         @Binds
-        fun provideDatastore(datastore: UserPreferencesDataSourceImpl): UserPreferencesDataSource
+        fun provideDatastore(datastore: PloggingPreferencesDataSourceImpl): PloggingPreferencesDataSource
     }
 
     @Module
@@ -42,6 +42,6 @@ object UserPreferencesModule {
     interface RepositoryModule {
         @Binds
         @Singleton
-        fun bindsUserPreferencesRepository(RepositoryImpl: UserPreferencesRepositoryImpl): UserPreferencesRepository
+        fun bindsPloggingPreferencesRepository(RepositoryImpl: PloggingPreferencesRepositoryImpl): PloggingPreferencesRepository
     }
 }

--- a/app/src/main/java/com/kpaas/plog/app/di/Qualifier.kt
+++ b/app/src/main/java/com/kpaas/plog/app/di/Qualifier.kt
@@ -9,3 +9,11 @@ annotation class PlogRetrofit
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
 annotation class AccessToken
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class PloggingPreferences
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class UserPreferences

--- a/app/src/main/java/com/kpaas/plog/core_ui/component/textfield/SearchTextField.kt
+++ b/app/src/main/java/com/kpaas/plog/core_ui/component/textfield/SearchTextField.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.kpaas.plog.R
 import com.kpaas.plog.core_ui.theme.Gray200
@@ -21,6 +22,7 @@ import com.kpaas.plog.core_ui.theme.Gray400
 import com.kpaas.plog.core_ui.theme.Gray600
 import com.kpaas.plog.core_ui.theme.White
 import com.kpaas.plog.core_ui.theme.body2Regular
+import timber.log.Timber
 
 @Composable
 fun SearchTextField(
@@ -29,6 +31,7 @@ fun SearchTextField(
     leadingIconDescription: String,
     placeholderText: String,
     onClick: () -> Unit,
+    onDeleteClick: () -> Unit,
     enabled: Boolean
 ) {
     TextField(
@@ -38,6 +41,13 @@ fun SearchTextField(
             Image(
                 imageVector = ImageVector.vectorResource(id = R.drawable.ic_plogging_search),
                 contentDescription = leadingIconDescription
+            )
+        },
+        trailingIcon = {
+            Image(
+                modifier = Modifier.clickable { onDeleteClick() },
+                imageVector = ImageVector.vectorResource(id = R.drawable.ic_search_delete),
+                contentDescription = null
             )
         },
         placeholder = {
@@ -67,5 +77,19 @@ fun SearchTextField(
         ),
         shape = RoundedCornerShape(12.dp),
         enabled = enabled
+    )
+}
+
+@Preview
+@Composable
+fun SearchTextFieldPreview() {
+    SearchTextField(
+        value = "검색어",
+        onValueChange = {},
+        leadingIconDescription = "검색",
+        placeholderText = "검색어를 입력해주세요",
+        onClick = {},
+        onDeleteClick = {},
+        enabled = true
     )
 }

--- a/app/src/main/java/com/kpaas/plog/data/datasource/PloggingPreferencesDataSource.kt
+++ b/app/src/main/java/com/kpaas/plog/data/datasource/PloggingPreferencesDataSource.kt
@@ -1,0 +1,38 @@
+package com.kpaas.plog.data.datasource
+
+import kotlinx.coroutines.flow.Flow
+
+interface PloggingPreferencesDataSource {
+    suspend fun saveButtonText(text: String)
+    fun getButtonText(): Flow<String>
+
+    suspend fun saveStartTime(startTime: Long)
+    fun getStartTime(): Flow<Long>
+
+    suspend fun saveStart(start: String)
+    fun getStart(): Flow<String>
+
+    suspend fun saveDestination(destination: String)
+    fun getDestination(): Flow<String>
+
+    suspend fun saveStopover(stopover: String)
+    fun getStopover(): Flow<String>
+
+    suspend fun saveSearchTextFieldVisible(visibility: Boolean)
+    fun getSearchTextFieldVisible(): Flow<Boolean>
+
+    suspend fun saveStopoverTextFieldVisible(visibility: Boolean)
+    fun getStopoverTextFieldVisible(): Flow<Boolean>
+
+    suspend fun saveAll(
+        buttonText: String,
+        startTime: Long,
+        start: String,
+        destination: String,
+        stopover: String,
+        searchTextFieldVisible: Boolean,
+        stopoverTextFieldVisible: Boolean
+    )
+
+    suspend fun clear()
+}

--- a/app/src/main/java/com/kpaas/plog/data/datasource/UserPreferencesDataSource.kt
+++ b/app/src/main/java/com/kpaas/plog/data/datasource/UserPreferencesDataSource.kt
@@ -6,9 +6,6 @@ interface UserPreferencesDataSource {
     suspend fun saveUserAccessToken(accessToken: String)
     fun getUserAccessToken(): Flow<String?>
 
-    suspend fun saveUserRefreshToken(refreshToken: String)
-    fun getUserRefreshToken(): Flow<String?>
-
     suspend fun saveCheckLogin(checkLogin: Boolean)
     fun getCheckLogin(): Flow<Boolean>
 

--- a/app/src/main/java/com/kpaas/plog/data/datasourceimpl/PloggingPreferencesDataSourceImpl.kt
+++ b/app/src/main/java/com/kpaas/plog/data/datasourceimpl/PloggingPreferencesDataSourceImpl.kt
@@ -21,10 +21,11 @@ class PloggingPreferencesDataSourceImpl @Inject constructor(
         }
     }
 
-    override fun getButtonText(): Flow<String> = dataStore.data.map { preferences ->
-        preferences[BUTTON_TEXT] ?: "시작하기"
+    override fun getButtonText(): Flow<String> {
+        return dataStore.data.map { preferences ->
+            preferences[BUTTON_TEXT] ?: "시작하기"
+        }
     }
-
 
     override suspend fun saveStartTime(startTime: Long) {
         dataStore.edit { preferences ->
@@ -32,8 +33,10 @@ class PloggingPreferencesDataSourceImpl @Inject constructor(
         }
     }
 
-    override fun getStartTime(): Flow<Long> = dataStore.data.map { preferences ->
-        preferences[START_TIME] ?: 0L
+    override fun getStartTime(): Flow<Long> {
+        return dataStore.data.map { preferences ->
+            preferences[START_TIME] ?: 0L
+        }
     }
 
     override suspend fun saveStart(start: String) {
@@ -42,8 +45,10 @@ class PloggingPreferencesDataSourceImpl @Inject constructor(
         }
     }
 
-    override fun getStart(): Flow<String> = dataStore.data.map { preferences ->
-        preferences[START] ?: ""
+    override fun getStart(): Flow<String> {
+        return dataStore.data.map { preferences ->
+            preferences[START] ?: ""
+        }
     }
 
     override suspend fun saveDestination(destination: String) {
@@ -52,8 +57,10 @@ class PloggingPreferencesDataSourceImpl @Inject constructor(
         }
     }
 
-    override fun getDestination(): Flow<String> = dataStore.data.map { preferences ->
-        preferences[DESTINATION] ?: ""
+    override fun getDestination(): Flow<String> {
+        return dataStore.data.map { preferences ->
+            preferences[DESTINATION] ?: ""
+        }
     }
 
     override suspend fun saveStopover(stopover: String) {
@@ -62,8 +69,10 @@ class PloggingPreferencesDataSourceImpl @Inject constructor(
         }
     }
 
-    override fun getStopover(): Flow<String> = dataStore.data.map { preferences ->
-        preferences[STOPOVER] ?: ""
+    override fun getStopover(): Flow<String> {
+        return dataStore.data.map { preferences ->
+            preferences[STOPOVER] ?: ""
+        }
     }
 
     override suspend fun saveSearchTextFieldVisible(visibility: Boolean) {

--- a/app/src/main/java/com/kpaas/plog/data/datasourceimpl/PloggingPreferencesDataSourceImpl.kt
+++ b/app/src/main/java/com/kpaas/plog/data/datasourceimpl/PloggingPreferencesDataSourceImpl.kt
@@ -1,0 +1,134 @@
+package com.kpaas.plog.data.datasourceimpl
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.longPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.kpaas.plog.app.di.PloggingPreferences
+import com.kpaas.plog.data.datasource.PloggingPreferencesDataSource
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+class PloggingPreferencesDataSourceImpl @Inject constructor(
+    @PloggingPreferences private val dataStore: DataStore<Preferences>
+) : PloggingPreferencesDataSource {
+    override suspend fun saveButtonText(text: String) {
+        dataStore.edit { preferences ->
+            preferences[BUTTON_TEXT] = text
+        }
+    }
+
+    override fun getButtonText(): Flow<String> = dataStore.data.map { preferences ->
+        preferences[BUTTON_TEXT] ?: "시작하기"
+    }
+
+
+    override suspend fun saveStartTime(startTime: Long) {
+        dataStore.edit { preferences ->
+            preferences[START_TIME] = startTime
+        }
+    }
+
+    override fun getStartTime(): Flow<Long> = dataStore.data.map { preferences ->
+        preferences[START_TIME] ?: 0L
+    }
+
+    override suspend fun saveStart(start: String) {
+        dataStore.edit { preferences ->
+            preferences[START] = start
+        }
+    }
+
+    override fun getStart(): Flow<String> = dataStore.data.map { preferences ->
+        preferences[START] ?: ""
+    }
+
+    override suspend fun saveDestination(destination: String) {
+        dataStore.edit { preferences ->
+            preferences[DESTINATION] = destination
+        }
+    }
+
+    override fun getDestination(): Flow<String> = dataStore.data.map { preferences ->
+        preferences[DESTINATION] ?: ""
+    }
+
+    override suspend fun saveStopover(stopover: String) {
+        dataStore.edit { preferences ->
+            preferences[STOPOVER] = stopover
+        }
+    }
+
+    override fun getStopover(): Flow<String> = dataStore.data.map { preferences ->
+        preferences[STOPOVER] ?: ""
+    }
+
+    override suspend fun saveSearchTextFieldVisible(visibility: Boolean) {
+        dataStore.edit { preferences ->
+            preferences[SEARCH_TEXT_FIELD_VISIBLE] = visibility
+        }
+    }
+
+    override fun getSearchTextFieldVisible(): Flow<Boolean> {
+        return dataStore.data.map { preferences ->
+            preferences[SEARCH_TEXT_FIELD_VISIBLE] ?: true
+        }
+    }
+
+    override suspend fun saveStopoverTextFieldVisible(visibility: Boolean) {
+        dataStore.edit { preferences ->
+            preferences[STOPOVER_TEXT_FIELD_VISIBLE] = visibility
+        }
+    }
+
+    override fun getStopoverTextFieldVisible(): Flow<Boolean> {
+        return dataStore.data.map { preferences ->
+            preferences[STOPOVER_TEXT_FIELD_VISIBLE] ?: false
+        }
+    }
+
+    override suspend fun saveAll(
+        buttonText: String,
+        startTime: Long,
+        start: String,
+        destination: String,
+        stopover: String,
+        searchTextFieldVisible: Boolean,
+        stopoverTextFieldVisible: Boolean
+    ) {
+        dataStore.edit { preferences ->
+            preferences[BUTTON_TEXT] = buttonText
+            preferences[START_TIME] = startTime
+            preferences[START] = start
+            preferences[DESTINATION] = destination
+            preferences[STOPOVER] = stopover
+            preferences[SEARCH_TEXT_FIELD_VISIBLE] = searchTextFieldVisible
+            preferences[STOPOVER_TEXT_FIELD_VISIBLE] = stopoverTextFieldVisible
+        }
+    }
+
+    override suspend fun clear() {
+        dataStore.edit { preferences ->
+            preferences.remove(BUTTON_TEXT)
+            preferences.remove(START_TIME)
+            preferences.remove(START)
+            preferences.remove(DESTINATION)
+            preferences.remove(STOPOVER)
+            preferences.remove(SEARCH_TEXT_FIELD_VISIBLE)
+            preferences.remove(STOPOVER_TEXT_FIELD_VISIBLE)
+        }
+    }
+
+    companion object {
+        val BUTTON_TEXT = stringPreferencesKey("button_text")
+        val START_TIME = longPreferencesKey("start_time")
+        val START = stringPreferencesKey("start")
+        val DESTINATION = stringPreferencesKey("destination")
+        val STOPOVER = stringPreferencesKey("stopover")
+        val SEARCH_TEXT_FIELD_VISIBLE = booleanPreferencesKey("search_text_field_visible")
+        val STOPOVER_TEXT_FIELD_VISIBLE = booleanPreferencesKey("stopover_text_field_visible")
+    }
+}

--- a/app/src/main/java/com/kpaas/plog/data/datasourceimpl/UserPreferencesDataSourceImpl.kt
+++ b/app/src/main/java/com/kpaas/plog/data/datasourceimpl/UserPreferencesDataSourceImpl.kt
@@ -5,6 +5,7 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
+import com.kpaas.plog.app.di.UserPreferences
 import com.kpaas.plog.data.datasource.UserPreferencesDataSource
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -12,7 +13,7 @@ import javax.inject.Inject
 
 class UserPreferencesDataSourceImpl @Inject constructor
     (
-    private val dataStore: DataStore<Preferences>
+    @UserPreferences private val dataStore: DataStore<Preferences>
 ) : UserPreferencesDataSource {
     private val USER_ACCESS_TOKEN = stringPreferencesKey("user_access_token")
     private val USER_REFRESH_TOKEN = stringPreferencesKey("user_refresh_token")

--- a/app/src/main/java/com/kpaas/plog/data/datasourceimpl/UserPreferencesDataSourceImpl.kt
+++ b/app/src/main/java/com/kpaas/plog/data/datasourceimpl/UserPreferencesDataSourceImpl.kt
@@ -11,12 +11,10 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
-class UserPreferencesDataSourceImpl @Inject constructor
-    (
+class UserPreferencesDataSourceImpl @Inject constructor(
     @UserPreferences private val dataStore: DataStore<Preferences>
 ) : UserPreferencesDataSource {
     private val USER_ACCESS_TOKEN = stringPreferencesKey("user_access_token")
-    private val USER_REFRESH_TOKEN = stringPreferencesKey("user_refresh_token")
     private val CHECK_LOGIN = booleanPreferencesKey("check_login")
 
     override suspend fun saveUserAccessToken(accessToken: String) {
@@ -27,16 +25,6 @@ class UserPreferencesDataSourceImpl @Inject constructor
 
     override fun getUserAccessToken(): Flow<String?> = dataStore.data.map { preferences ->
         preferences[USER_ACCESS_TOKEN]
-    }
-
-    override suspend fun saveUserRefreshToken(refreshToken: String) {
-        dataStore.edit { preferences ->
-            preferences[USER_REFRESH_TOKEN] = refreshToken
-        }
-    }
-
-    override fun getUserRefreshToken(): Flow<String?> = dataStore.data.map { preferences ->
-        preferences[USER_REFRESH_TOKEN]
     }
 
     override suspend fun saveCheckLogin(checkLogin: Boolean) {
@@ -52,7 +40,6 @@ class UserPreferencesDataSourceImpl @Inject constructor
     override suspend fun clear() {
         dataStore.edit { preferences ->
             preferences.remove(USER_ACCESS_TOKEN)
-            preferences.remove(USER_REFRESH_TOKEN)
             preferences.remove(CHECK_LOGIN)
         }
     }

--- a/app/src/main/java/com/kpaas/plog/data/repositoryimpl/PloggingPreferencesRepositoryImpl.kt
+++ b/app/src/main/java/com/kpaas/plog/data/repositoryimpl/PloggingPreferencesRepositoryImpl.kt
@@ -36,13 +36,18 @@ class PloggingPreferencesRepositoryImpl @Inject constructor(
         dataSource.saveDestination(destination)
     }
 
-    override fun getDestination(): Flow<String> = dataSource.getDestination()
+    override fun getDestination(): Flow<String> {
+        return dataSource.getDestination()
+    }
 
     override suspend fun saveStopover(stopover: String) {
         dataSource.saveStopover(stopover)
     }
 
-    override fun getStopover(): Flow<String> = dataSource.getStopover()
+    override fun getStopover(): Flow<String> {
+        return dataSource.getStopover()
+    }
+
     override suspend fun saveSearchTextFieldVisible(visibility: Boolean) {
         dataSource.saveSearchTextFieldVisible(visibility)
     }
@@ -82,5 +87,4 @@ class PloggingPreferencesRepositoryImpl @Inject constructor(
     override suspend fun clear() {
         dataSource.clear()
     }
-
 }

--- a/app/src/main/java/com/kpaas/plog/data/repositoryimpl/PloggingPreferencesRepositoryImpl.kt
+++ b/app/src/main/java/com/kpaas/plog/data/repositoryimpl/PloggingPreferencesRepositoryImpl.kt
@@ -1,0 +1,86 @@
+package com.kpaas.plog.data.repositoryimpl
+
+import com.kpaas.plog.data.datasource.PloggingPreferencesDataSource
+import com.kpaas.plog.domain.repository.PloggingPreferencesRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class PloggingPreferencesRepositoryImpl @Inject constructor(
+    private val dataSource: PloggingPreferencesDataSource
+) : PloggingPreferencesRepository {
+    override suspend fun saveButtonText(text: String) {
+        dataSource.saveButtonText(text)
+    }
+
+    override fun getButtonText(): Flow<String> {
+        return dataSource.getButtonText()
+    }
+
+    override suspend fun saveStartTime(startTime: Long) {
+        return dataSource.saveStartTime(startTime)
+    }
+
+    override fun getStartTime(): Flow<Long> {
+        return dataSource.getStartTime()
+    }
+
+    override suspend fun saveStart(start: String) {
+        dataSource.saveStart(start)
+    }
+
+    override fun getStart(): Flow<String> {
+        return dataSource.getStart()
+    }
+
+    override suspend fun saveDestination(destination: String) {
+        dataSource.saveDestination(destination)
+    }
+
+    override fun getDestination(): Flow<String> = dataSource.getDestination()
+
+    override suspend fun saveStopover(stopover: String) {
+        dataSource.saveStopover(stopover)
+    }
+
+    override fun getStopover(): Flow<String> = dataSource.getStopover()
+    override suspend fun saveSearchTextFieldVisible(visibility: Boolean) {
+        dataSource.saveSearchTextFieldVisible(visibility)
+    }
+
+    override fun getSearchTextFieldVisible(): Flow<Boolean> {
+        return dataSource.getSearchTextFieldVisible()
+    }
+
+    override suspend fun saveStopoverTextFieldVisible(visibility: Boolean) {
+        dataSource.saveStopoverTextFieldVisible(visibility)
+    }
+
+    override fun getStopoverTextFieldVisible(): Flow<Boolean> {
+        return dataSource.getStopoverTextFieldVisible()
+    }
+
+    override suspend fun saveAll(
+        buttonText: String,
+        startTime: Long,
+        start: String,
+        destination: String,
+        stopover: String,
+        searchTextFieldVisible: Boolean,
+        stopoverTextFieldVisible: Boolean
+    ) {
+        dataSource.saveAll(
+            buttonText,
+            startTime,
+            start,
+            destination,
+            stopover,
+            searchTextFieldVisible,
+            stopoverTextFieldVisible
+        )
+    }
+
+    override suspend fun clear() {
+        dataSource.clear()
+    }
+
+}

--- a/app/src/main/java/com/kpaas/plog/data/repositoryimpl/UserPreferencesRepositoryImpl.kt
+++ b/app/src/main/java/com/kpaas/plog/data/repositoryimpl/UserPreferencesRepositoryImpl.kt
@@ -15,12 +15,6 @@ class UserPreferencesRepositoryImpl @Inject constructor(
 
     override fun getUserAccessToken(): Flow<String?> = dataSource.getUserAccessToken()
 
-    override suspend fun saveUserRefreshToken(refreshToken: String) {
-        dataSource.saveUserRefreshToken(refreshToken)
-    }
-
-    override fun getUserRefreshToken(): Flow<String?> = dataSource.getUserRefreshToken()
-
     override suspend fun saveCheckLogin(checkLogin: Boolean) {
         dataSource.saveCheckLogin(checkLogin)
     }

--- a/app/src/main/java/com/kpaas/plog/domain/repository/PloggingPreferencesRepository.kt
+++ b/app/src/main/java/com/kpaas/plog/domain/repository/PloggingPreferencesRepository.kt
@@ -1,0 +1,38 @@
+package com.kpaas.plog.domain.repository
+
+import kotlinx.coroutines.flow.Flow
+
+interface PloggingPreferencesRepository {
+    suspend fun saveButtonText(text: String)
+    fun getButtonText(): Flow<String>
+
+    suspend fun saveStartTime(startTime: Long)
+    fun getStartTime(): Flow<Long>
+
+    suspend fun saveStart(start: String)
+    fun getStart(): Flow<String>
+
+    suspend fun saveDestination(destination: String)
+    fun getDestination(): Flow<String>
+
+    suspend fun saveStopover(stopover: String)
+    fun getStopover(): Flow<String>
+
+    suspend fun saveSearchTextFieldVisible(visibility: Boolean)
+    fun getSearchTextFieldVisible(): Flow<Boolean>
+
+    suspend fun saveStopoverTextFieldVisible(visibility: Boolean)
+    fun getStopoverTextFieldVisible(): Flow<Boolean>
+
+    suspend fun saveAll(
+        buttonText: String,
+        startTime: Long,
+        start: String,
+        destination: String,
+        stopover: String,
+        searchTextFieldVisible: Boolean,
+        stopoverTextFieldVisible: Boolean
+    )
+
+    suspend fun clear()
+}

--- a/app/src/main/java/com/kpaas/plog/domain/repository/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/kpaas/plog/domain/repository/UserPreferencesRepository.kt
@@ -4,15 +4,9 @@ import kotlinx.coroutines.flow.Flow
 
 interface UserPreferencesRepository {
     suspend fun saveUserAccessToken(accessToken: String)
-
     fun getUserAccessToken(): Flow<String?>
 
-    suspend fun saveUserRefreshToken(refreshToken: String)
-
-    fun getUserRefreshToken(): Flow<String?>
-
     suspend fun saveCheckLogin(checkLogin: Boolean)
-
     fun getCheckLogin(): Flow<Boolean>
 
     suspend fun clear()

--- a/app/src/main/java/com/kpaas/plog/presentation/auth/screen/LoginScreen.kt
+++ b/app/src/main/java/com/kpaas/plog/presentation/auth/screen/LoginScreen.kt
@@ -55,15 +55,11 @@ fun LoginRoute(
     LaunchedEffect(loginState) {
         when (loginState) {
             is UiState.Success -> {
-                val accessToken = (loginState as UiState.Success).data[0]
-                val refreshToken = (loginState as UiState.Success).data[1]
-
-                if(refreshToken == loginViewModel.getUserRefreshToken().first()) {
-                    loginViewModel.saveCheckLogin(true)
-                    authNavigator.navigateMain()
-                } else {
-                    authNavigator.navigateSignup(accessToken, refreshToken)
-                }
+                // 나중에 신규 유저 여부에 따라 분기 처리 할 것
+                val data = (loginState as UiState.Success).data
+                loginViewModel.saveUserAccessToken(data)
+                loginViewModel.saveCheckLogin(true)
+                authNavigator.navigateMain()
             }
 
             is UiState.Failure -> {

--- a/app/src/main/java/com/kpaas/plog/presentation/auth/screen/SignupScreen.kt
+++ b/app/src/main/java/com/kpaas/plog/presentation/auth/screen/SignupScreen.kt
@@ -67,7 +67,6 @@ fun SignupRoute(
     SignupScreen(
         onNextButtonClick = {
             loginViewModel.saveUserAccessToken(accessToken)
-            loginViewModel.saveUserRefreshToken(refreshToken)
             loginViewModel.saveCheckLogin(true)
             authNavigator.navigateBoarding()
         },

--- a/app/src/main/java/com/kpaas/plog/presentation/auth/viewmodel/LoginViewModel.kt
+++ b/app/src/main/java/com/kpaas/plog/presentation/auth/viewmodel/LoginViewModel.kt
@@ -23,8 +23,8 @@ import kotlin.coroutines.resumeWithException
 class LoginViewModel @Inject constructor(
     private val userPreferencesRepository: UserPreferencesRepository
 ) : ViewModel() {
-    private val _loginState = MutableStateFlow<UiState<List<String>>>(UiState.Empty)
-    val loginState: StateFlow<UiState<List<String>>> = _loginState
+    private val _loginState = MutableStateFlow<UiState<String>>(UiState.Empty)
+    val loginState: StateFlow<UiState<String>> = _loginState
 
     private var accessToken: String? = null
     private var refreshToken: String? = null
@@ -65,7 +65,7 @@ class LoginViewModel @Inject constructor(
             if (error != null) {
                 _loginState.value = UiState.Failure(error.localizedMessage)
             } else if (user != null) {
-                _loginState.value = UiState.Success(listOf(accessToken, refreshToken))
+                _loginState.value = UiState.Success(accessToken)
             }
         }
     }
@@ -77,8 +77,7 @@ class LoginViewModel @Inject constructor(
                     // 네이버 로그인 인증이 성공했을 때 수행할 코드
                     val accessToken = NaverIdLoginSDK.getAccessToken()
                     val refreshToken = NaverIdLoginSDK.getRefreshToken()
-
-                   _loginState.value = UiState.Success(listOf(accessToken!!, refreshToken!!))
+                    accessToken?.let { _loginState.value = UiState.Success(it) }
                 }
 
                 override fun onFailure(httpStatus: Int, message: String) {
@@ -101,14 +100,6 @@ class LoginViewModel @Inject constructor(
     fun saveUserAccessToken(accessToken: String) {
         viewModelScope.launch {
             userPreferencesRepository.saveUserAccessToken(accessToken)
-        }
-    }
-
-    fun getUserRefreshToken() = userPreferencesRepository.getUserRefreshToken()
-
-    fun saveUserRefreshToken(refreshToken: String) {
-        viewModelScope.launch {
-            userPreferencesRepository.saveUserRefreshToken(refreshToken)
         }
     }
 

--- a/app/src/main/java/com/kpaas/plog/presentation/plogging/screen/PloggingScreen.kt
+++ b/app/src/main/java/com/kpaas/plog/presentation/plogging/screen/PloggingScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.BottomSheetScaffold
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.rememberBottomSheetScaffoldState
@@ -137,6 +138,7 @@ fun PloggingScreen(
 
     BottomSheetScaffold(
         sheetPeekHeight = 120.dp,
+        sheetShape = RoundedCornerShape(topStart = 25.dp, topEnd = 25.dp),
         scaffoldState = scaffoldState,
         sheetContent = {
             Column(

--- a/app/src/main/java/com/kpaas/plog/presentation/plogging/screen/PloggingScreen.kt
+++ b/app/src/main/java/com/kpaas/plog/presentation/plogging/screen/PloggingScreen.kt
@@ -102,9 +102,15 @@ fun PloggingScreen(
     }
 
     LaunchedEffect(startAddress, destinationAddress, stopoverAddress) {
-        ploggingViewModel.saveStart(startAddress)
-        ploggingViewModel.saveDestination(destinationAddress)
-        ploggingViewModel.saveStopover(stopoverAddress)
+        if (startAddress.isNotBlank()) {
+            ploggingViewModel.saveStart(startAddress)
+        }
+        if (destinationAddress.isNotBlank()) {
+            ploggingViewModel.saveDestination(destinationAddress)
+        }
+        if (stopoverAddress.isNotBlank()) {
+            ploggingViewModel.saveStopover(stopoverAddress)
+        }
     }
 
     if (showPloggingDialog) {
@@ -198,31 +204,43 @@ fun PloggingScreen(
             ) {
                 if (isSearchTextFieldVisible) {
                     SearchTextField(
-                        value = start,
+                        value = startAddress,
                         onValueChange = { ploggingViewModel.saveStart(it) },
                         leadingIconDescription = stringResource(id = R.string.img_plogging_start_description),
                         placeholderText = stringResource(id = R.string.tv_plogging_start),
                         onClick = { onSearchClick("start") },
+                        onDeleteClick = {
+                            searchViewModel.deleteStart()
+                            ploggingViewModel.saveStart("")
+                        },
                         enabled = false
                     )
                     Spacer(modifier = Modifier.height(5.dp))
                     if (isStopoverTextFieldVisible) {
                         SearchTextField(
-                            value = stopover,
+                            value = stopoverAddress,
                             onValueChange = { ploggingViewModel.saveStopover(it) },
                             leadingIconDescription = stringResource(id = R.string.img_plogging_stopover_description),
                             placeholderText = stringResource(id = R.string.tv_plogging_stopover),
                             onClick = { onSearchClick("stopover") },
+                            onDeleteClick = {
+                                searchViewModel.deleteStopover()
+                                ploggingViewModel.saveStopover("")
+                            },
                             enabled = false
                         )
                         Spacer(modifier = Modifier.height(5.dp))
                     }
                     SearchTextField(
-                        value = destination,
+                        value = destinationAddress,
                         onValueChange = { ploggingViewModel.saveDestination(it) },
                         leadingIconDescription = stringResource(id = R.string.img_plogging_destination_description),
                         placeholderText = stringResource(id = R.string.tv_plogging_destination),
                         onClick = { onSearchClick("destination") },
+                        onDeleteClick = {
+                            searchViewModel.deleteDestination()
+                            ploggingViewModel.saveDestination("")
+                        },
                         enabled = false
                     )
                     PlogStopoverButton(

--- a/app/src/main/java/com/kpaas/plog/presentation/plogging/viewmodel/PloggingViewModel.kt
+++ b/app/src/main/java/com/kpaas/plog/presentation/plogging/viewmodel/PloggingViewModel.kt
@@ -1,0 +1,78 @@
+package com.kpaas.plog.presentation.plogging.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.kpaas.plog.domain.repository.PloggingPreferencesRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class PloggingViewModel @Inject constructor(
+    private val ploggingPreferencesRepository: PloggingPreferencesRepository
+) : ViewModel() {
+
+    fun saveAllPloggingData(
+        buttonText: String,
+        startTime: Long,
+        start: String,
+        destination: String,
+        stopover: String,
+        searchTextFieldVisible: Boolean,
+        stopoverTextFieldVisible: Boolean
+    ) {
+        viewModelScope.launch {
+            ploggingPreferencesRepository.saveAll(
+                buttonText = buttonText,
+                startTime = startTime,
+                start = start,
+                destination = destination,
+                stopover = stopover,
+                searchTextFieldVisible = searchTextFieldVisible,
+                stopoverTextFieldVisible = stopoverTextFieldVisible
+            )
+        }
+    }
+
+    fun getButtonText() = ploggingPreferencesRepository.getButtonText()
+
+    fun saveStopoverTextFieldVisible(visibility: Boolean) {
+        viewModelScope.launch {
+            ploggingPreferencesRepository.saveStopoverTextFieldVisible(visibility)
+        }
+    }
+
+    fun saveStart(start: String) {
+        viewModelScope.launch {
+            ploggingPreferencesRepository.saveStart(start)
+        }
+    }
+
+    fun getStart() = ploggingPreferencesRepository.getStart()
+
+    fun saveDestination(destination: String) {
+        viewModelScope.launch {
+            ploggingPreferencesRepository.saveDestination(destination)
+        }
+    }
+
+    fun getDestination() = ploggingPreferencesRepository.getDestination()
+
+    fun saveStopover(stopover: String) {
+        viewModelScope.launch {
+            ploggingPreferencesRepository.saveStopover(stopover)
+        }
+    }
+
+    fun getStopover() = ploggingPreferencesRepository.getStopover()
+
+    fun getStartTime() = ploggingPreferencesRepository.getStartTime()
+    fun getSearchTextFieldVisible() = ploggingPreferencesRepository.getSearchTextFieldVisible()
+    fun getStopoverTextFieldVisible() = ploggingPreferencesRepository.getStopoverTextFieldVisible()
+
+    fun clear() {
+        viewModelScope.launch {
+            ploggingPreferencesRepository.clear()
+        }
+    }
+}

--- a/app/src/main/java/com/kpaas/plog/presentation/profile/screen/ProfileScreen.kt
+++ b/app/src/main/java/com/kpaas/plog/presentation/profile/screen/ProfileScreen.kt
@@ -64,11 +64,10 @@ fun ProfileRoute(
             navigator.navigateBookmark()
         },
         onLogoutClick = {
-            loginViewModel.saveCheckLogin(false)
+            loginViewModel.clear()
             navigator.navigateLogin()
         },
         onLeaveClick = {
-            loginViewModel.saveCheckLogin(false)
             loginViewModel.clear()
             navigator.navigateLogin()
         }

--- a/app/src/main/java/com/kpaas/plog/presentation/report/screen/ReportWriteScreen.kt
+++ b/app/src/main/java/com/kpaas/plog/presentation/report/screen/ReportWriteScreen.kt
@@ -143,6 +143,10 @@ fun ReportWriteScreen(
                 leadingIconDescription = stringResource(R.string.tv_report_write_search_description),
                 placeholderText = stringResource(R.string.tv_report_write_placeholder),
                 onClick = { onSearchClick("reportWrite") },
+                onDeleteClick = {
+                    address = ""
+                    searchViewModel.deleteReportAddress()
+                },
                 enabled = false
             )
             Spacer(modifier = Modifier.height(27.dp))
@@ -152,7 +156,7 @@ fun ReportWriteScreen(
                     contentDescription = null,
                     modifier = Modifier
                         .fillMaxWidth()
-                        .height(134.dp)
+                        .height(180.dp)
                         .clip(RoundedCornerShape(12.dp))
                         .clickable { galleryLauncher.launch("image/*") },
                     contentScale = ContentScale.FillBounds
@@ -161,7 +165,7 @@ fun ReportWriteScreen(
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .height(134.dp)
+                        .height(180.dp)
                         .background(
                             color = White,
                             shape = RoundedCornerShape(12.dp)

--- a/app/src/main/java/com/kpaas/plog/presentation/search/screen/SearchScreen.kt
+++ b/app/src/main/java/com/kpaas/plog/presentation/search/screen/SearchScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -50,6 +51,8 @@ fun SearchScreen(
     onItemClick: () -> Unit,
 ) {
     var value by remember { mutableStateOf("") }
+    val keyboardController = LocalSoftwareKeyboardController.current
+
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -62,7 +65,10 @@ fun SearchScreen(
             Image(
                 modifier = Modifier
                     .padding(end = 20.dp)
-                    .clickable { onBackClick() },
+                    .clickable {
+                        keyboardController?.hide()
+                        onBackClick()
+                    },
                 imageVector = ImageVector.vectorResource(id = R.drawable.ic_my_report_back),
                 contentDescription = null
             )
@@ -72,6 +78,7 @@ fun SearchScreen(
                 leadingIconDescription = stringResource(R.string.tv_search_description),
                 placeholderText = stringResource(R.string.tv_search_placeholder),
                 onClick = { },
+                onDeleteClick = { value = "" },
                 enabled = true
             )
         }


### PR DESCRIPTION
## ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- merge할 브랜치의 위치를 확인해 주세요.(main❌/develop⭕)
- 리뷰가 필요한 경우 리뷰어를 지정해 주세요.
- 리뷰는 PR이 올라오면 최대한 빠르게 진행합니다.
- P1 단계의 리뷰는 빠르게 확인 후 반영합니다.
- Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.

## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #49 

## 📎 𝗪𝗼𝗿𝗸 𝗗𝗲𝘀𝗰𝗿𝗶𝗽𝘁𝗶𝗼𝗻
- sharedPreferences -> datastore 로 마이그레이션
- 자동 로그인 로직 수정
- TextField에 삭제 버튼 추가 -> 버튼 클릭 시  value 빈 값으로 변경

## 📷 𝗦𝗰𝗿𝗲𝗲𝗻𝘀𝗵𝗼𝘁
https://github.com/user-attachments/assets/179d11d4-b540-4081-aa10-7fd178e57603

## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀
